### PR TITLE
Add Encrypt and TrustServerCertificate to Connection Strings

### DIFF
--- a/WorkloadTools/SqlConnectionInfo.cs
+++ b/WorkloadTools/SqlConnectionInfo.cs
@@ -13,6 +13,8 @@ namespace WorkloadTools
         public bool UseIntegratedSecurity { get; set; }
         public string UserName { get; set; }
         public string Password { get; set; }
+        public bool Encrypt { get; set; } = false;
+        public bool TrustServerCertificate { get; set; } = false;
         public string ApplicationName { get; set; } = "WorkloadTools";
         public Dictionary<string, string> DatabaseMap { get; set;} = new Dictionary<string, string>();
             
@@ -48,6 +50,14 @@ namespace WorkloadTools
                 if (!String.IsNullOrEmpty(ApplicationName))
                 {
                     connectionString += "Application Name = "+ ApplicationName +"; ";
+                }
+                if (Encrypt)
+                {
+                    connectionString += "Encrypt = true; ";
+                }
+                if (TrustServerCertificate)
+                {
+                    connectionString += "TrustServerCertificate = true; ";
                 }
                 return connectionString;
             }

--- a/WorkloadViewer/Model/SqlConnectionInfo.cs
+++ b/WorkloadViewer/Model/SqlConnectionInfo.cs
@@ -14,6 +14,8 @@ namespace WorkloadViewer.Model
         public bool UseIntegratedSecurity { get; set; }
         public string UserName { get; set; }
         public string Password { get; set; }
+        public bool Encrypt { get; set; } = false;
+        public bool TrustServerCertificate { get; set; } = false;
         public string ApplicationName { get; set; } = "WorkloadAnalyzer";
 
         public string ConnectionString
@@ -41,6 +43,14 @@ namespace WorkloadViewer.Model
                 if (!String.IsNullOrEmpty(ApplicationName))
                 {
                     connectionString += "Application Name = " + ApplicationName + "; ";
+                }
+                if (Encrypt)
+                {
+                    connectionString += "Encrypt = true; ";
+                }
+                if (TrustServerCertificate)
+                {
+                    connectionString += "TrustServerCertificate = true; ";
                 }
                 return connectionString;
             }


### PR DESCRIPTION
This PR adds the capability to use the Encrypt=true and TrustServerCertificate=true to connection properties. Tested against local databases using the following JSON:

```
 "ConnectionInfo": {
        "ServerName": "",
        "UseWindowsAuthentication": true,
	"Encrypt": true,
	"TrustServerCertificate":` true
      }
```