### PR TITLE
Parameterize max pool size

### DIFF
--- a/WorkloadTools/Consumer/Replay/ReplayWorker.cs
+++ b/WorkloadTools/Consumer/Replay/ReplayWorker.cs
@@ -83,16 +83,10 @@ namespace WorkloadTools.Consumer.Replay
         {
             logger.Trace($"Worker [{Name}] - Connecting to server {ConnectionInfo.ServerName} for replay...");
             ConnectionInfo.DatabaseMap = this.DatabaseMap;
-            string connString = BuildConnectionString();
+            string connString = ConnectionInfo.ConnectionString;
             conn = new SqlConnection(connString);
             conn.Open();
             logger.Trace($"Worker [{Name}] - Connected");
-        }
-
-        private string BuildConnectionString()
-        {
-            string connectionString = ConnectionInfo.ConnectionString + "; max pool size=500"; 
-            return connectionString;
         }
 
         public void Start()

--- a/WorkloadTools/SqlConnectionInfo.cs
+++ b/WorkloadTools/SqlConnectionInfo.cs
@@ -16,13 +16,15 @@ namespace WorkloadTools
         public bool Encrypt { get; set; } = false;
         public bool TrustServerCertificate { get; set; } = false;
         public string ApplicationName { get; set; } = "WorkloadTools";
+        public string MaxPoolSize { get; set; } = "500";
         public Dictionary<string, string> DatabaseMap { get; set;} = new Dictionary<string, string>();
             
         public string ConnectionString
         {
             get
             {
-                string connectionString = "Data Source=" + ServerName + ";";
+                string connectionString = "Data Source=" + ServerName + "; ";
+                connectionString += "Max Pool Size = " + MaxPoolSize + "; ";
                 if (String.IsNullOrEmpty(DatabaseName))
                 {
                     connectionString += "Initial Catalog = master; ";

--- a/WorkloadTools/SqlConnectionInfo.cs
+++ b/WorkloadTools/SqlConnectionInfo.cs
@@ -16,7 +16,7 @@ namespace WorkloadTools
         public bool Encrypt { get; set; } = false;
         public bool TrustServerCertificate { get; set; } = false;
         public string ApplicationName { get; set; } = "WorkloadTools";
-        public string MaxPoolSize { get; set; } = "500";
+        public int MaxPoolSize { get; set; } = 500;
         public Dictionary<string, string> DatabaseMap { get; set;} = new Dictionary<string, string>();
             
         public string ConnectionString


### PR DESCRIPTION
Updating SqlConnectionInto support a MaxPoolSize parameter. This maintains the default of 500 that was in ReplayConsumer.

Addresses #98 