### PR TITLE
Adjusting SqlCommand CommandTimeOut

### DIFF
--- a/WorkloadTools/Listener/ExtendedEvents/FileTargetXEventDataReader.cs
+++ b/WorkloadTools/Listener/ExtendedEvents/FileTargetXEventDataReader.cs
@@ -93,6 +93,7 @@ namespace WorkloadTools.Listener.ExtendedEvents
             using (SqlCommand cmd = conn.CreateCommand())
             {
                 cmd.CommandText = sqlXE;
+                cmd.CommandTimeout = 0;
 
                 var paramPath = cmd.Parameters.Add("@filename", System.Data.SqlDbType.NVarChar, 260);
                 if (ServerType != ExtendedEventsWorkloadListener.ServerType.AzureSqlDatabase)


### PR DESCRIPTION
Adjusting SqlCommand CommandTimeOut used to run query with fn_xe_file_target_read_file to read extended event files. Setting it to zero (no limit) to wait indefinitely to be able to deal with large xe files.
Addresses issue #96 