### PR TITLE
Update WorkloadFileWriterConsumer.cs

### DIFF
--- a/WorkloadTools/Consumer/WorkloadFile/WorkloadFileWriterConsumer.cs
+++ b/WorkloadTools/Consumer/WorkloadFile/WorkloadFileWriterConsumer.cs
@@ -75,7 +75,8 @@ namespace WorkloadTools.Consumer.WorkloadFile
                 UPDATE Events SET cpu = $cpu,
                                   duration = $duration,
                                   reads = $reads,
-                                  writes = $writes
+                                  writes = $writes,
+                                  sql_text = $sql_text
                 WHERE row_id = (SELECT row_id 
                                 FROM Events
                                 WHERE session_id = $session_id
@@ -215,6 +216,7 @@ namespace WorkloadTools.Consumer.WorkloadFile
             events_update_cmd.Parameters.AddWithValue("$duration", evt.Duration);
             events_update_cmd.Parameters.AddWithValue("$reads", evt.Reads);
             events_update_cmd.Parameters.AddWithValue("$writes", evt.Writes);
+            events_update_cmd.Parameters.AddWithValue("$sql_text", evt.Text);
 
             int rowcount;
             rowcount = events_update_cmd.ExecuteNonQuery();


### PR DESCRIPTION
Fixing issue with prepared statements. SqlWorkload rely on the prep handle set on @p1 variable and this is only set on the completed event.
Adjusting the update to also update the sql_text with the completed event command.

![image](https://user-images.githubusercontent.com/23176207/188179218-59774e7c-2f48-41d4-9523-8329bc7f4a44.png)
