### PR TITLE
Increase ReplayOffset precision with stopwatch timer

### DIFF
--- a/WorkloadTools/Consumer/Replay/ReplayWorker.cs
+++ b/WorkloadTools/Consumer/Replay/ReplayWorker.cs
@@ -4,6 +4,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -17,6 +18,8 @@ namespace WorkloadTools.Consumer.Replay
 {
     class ReplayWorker : IDisposable
     {
+        private const int ReplayOffsetSleepThresholdMs = 50;
+
         private static Logger logger = LogManager.GetCurrentClassLogger();
         public bool DisplayWorkerStats { get; set; }
         public bool ConsumeResults { get; set; }
@@ -162,7 +165,7 @@ namespace WorkloadTools.Consumer.Replay
             {
                 if (stopped)
                     return null;
-                
+
                 _spinWait.SpinOnce();
             }
             return result;
@@ -270,33 +273,34 @@ namespace WorkloadTools.Consumer.Replay
                     conn.ChangeDatabase(command.Database);
                 }
 
-                // if the command comes with a replay offset, do it now
-                // the offset in milliseconds is set in
-                // FileWorkloadListener
+                // If the command comes with a replay offset, evaluate it now.
+                // The offset in milliseconds is set in FileWorkloadListener.
                 // The other listeners do not set this value, as they
                 // already come with the original timing
                 if (command.ReplayOffset > 0)
                 {
-                    // I am using 7 here as an average compensation for sleep
-                    // fluctuations due to Windows preemptive scheduling
-                    while((DateTime.Now - StartTime).TotalMilliseconds < command.ReplayOffset - 7)
+                    double delay = command.ReplayOffset - (DateTime.Now - StartTime).TotalMilliseconds;
+                    // Delay execution only if necessary
+                    if (delay > 0)
                     {
-                        // Thread.Sleep will not sleep exactly 1 millisecond.
-                        // It will yield the current thread and put it back 
-                        // in the runnable queue once the sleep delay has expired.
-                        // This means that the actual sleep time before the 
-                        // current thread gains back control can be much higher 
-                        // (15 milliseconds or more)
-                        // However we do not need to be super precise here: 
-                        // each command has a requested offset from the beginning
+                        // Each command has a requested offset from the beginning
                         // of the workload and this class does its best to respect it.
                         // If the previous commands take longer in the target environment
                         // the offset cannot be respected and the command will execute
                         // without further waits, but there is no way to recover 
                         // the delay that has built up to that point.
-                        Thread.Sleep(1);
+
+                        var stopwatch = Stopwatch.StartNew();
+                        while (stopwatch.Elapsed.TotalMilliseconds < delay)
+                        {
+                            // If we're getting close to the command time then don't sleep,
+                            // we need higher accuracy to keep workers on time so stay in a tigher loop
+                            if ((delay - stopwatch.Elapsed.TotalMilliseconds) < ReplayOffsetSleepThresholdMs)
+                                continue; // Immediately re-evaluate
+                            else
+                                Thread.Sleep(1);
+                        }
                     }
-                    
                 }
 
                 using (SqlCommand cmd = new SqlCommand(command.CommandText))
@@ -374,7 +378,7 @@ namespace WorkloadTools.Consumer.Replay
 
                 if (StopOnError)
                 {
-                    
+
                     logger.Error($"Worker[{Name}] - Sequence[{command.EventSequence}] - Error: \n{command.CommandText}");
                     ClearPool(conn);
                     throw;
@@ -402,12 +406,12 @@ namespace WorkloadTools.Consumer.Replay
                 if (StopOnError)
                 {
                     logger.Error($"Worker[{Name}] - Sequence[{command.EventSequence}] - Error: \n{command.CommandText}");
-                    ClearPool(conn); 
+                    ClearPool(conn);
                     throw;
                 }
                 else
                 {
-                	logger.Error($"Worker [{Name}] - Sequence[{command.EventSequence}] - Error: {e.Message}");
+                    logger.Error($"Worker [{Name}] - Sequence[{command.EventSequence}] - Error: {e.Message}");
                     logger.Error(e.StackTrace);
 
                     ClearPool(conn);


### PR DESCRIPTION
I have attempted to increase the accuracy  of the replay offset execution by putting the cpu in a tighter loop when near to the desired execution time.

This comes at the expense of slightly higher cpu usage, but I believe this trade off is well worth it. High replay accuracy is important for two main reasons. The first reason is to keep quick successive commands on time within a single thread. The second reason is to keep concurrent threads on time relative to each other. This helps keep the replay in sync and avoids unnecessary database exceptions such as foreign key violations.