### PR TITLE
Update target framework to .net 4.8 for VS2022

### DIFF
--- a/ConvertWorkload/App.config
+++ b/ConvertWorkload/App.config
@@ -1,13 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup useLegacyV2RuntimeActivationPolicy="true"> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.SqlServer.XE.Core" publicKeyToken="89845dcd8080cc91" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-14.100.0.0" newVersion="14.100.0.0" />
+        <assemblyIdentity name="Microsoft.SqlServer.XE.Core" publicKeyToken="89845dcd8080cc91" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-14.100.0.0" newVersion="14.100.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/ConvertWorkload/ConvertWorkload.csproj
+++ b/ConvertWorkload/ConvertWorkload.csproj
@@ -8,12 +8,13 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>ConvertWorkload</RootNamespace>
     <AssemblyName>ConvertWorkload</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/SqlWorkload/SqlWorkload.csproj
+++ b/SqlWorkload/SqlWorkload.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>SqlWorkload</RootNamespace>
     <AssemblyName>SqlWorkload</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/SqlWorkload/app.config
+++ b/SqlWorkload/app.config
@@ -1,15 +1,15 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.SqlServer.XE.Core" publicKeyToken="89845dcd8080cc91" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-14.100.0.0" newVersion="14.100.0.0" />
+        <assemblyIdentity name="Microsoft.SqlServer.XE.Core" publicKeyToken="89845dcd8080cc91" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-14.100.0.0" newVersion="14.100.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
-    <gcConcurrent enabled="false" />
+    <gcConcurrent enabled="false"/>
   </runtime>
 </configuration>

--- a/WorkloadTools/Properties/Settings.Designer.cs
+++ b/WorkloadTools/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace WorkloadTools.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.3.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/WorkloadTools/WorkloadTools.csproj
+++ b/WorkloadTools/WorkloadTools.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WorkloadTools</RootNamespace>
     <AssemblyName>WorkloadTools</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/WorkloadTools/app.config
+++ b/WorkloadTools/app.config
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
         <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <section name="WorkloadTools.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+            <section name="WorkloadTools.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
         </sectionGroup>
     </configSections>
     <applicationSettings>
@@ -18,9 +18,9 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.SqlServer.XE.Core" publicKeyToken="89845dcd8080cc91" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-14.100.0.0" newVersion="14.100.0.0" />
+        <assemblyIdentity name="Microsoft.SqlServer.XE.Core" publicKeyToken="89845dcd8080cc91" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-14.100.0.0" newVersion="14.100.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/WorkloadTools/packages.config
+++ b/WorkloadTools/packages.config
@@ -4,6 +4,6 @@
   <package id="FastMember" version="1.5.0" targetFramework="net461" />
   <package id="Microsoft.SqlServer.SqlManagementObjects" version="140.17279.0" targetFramework="net40" />
   <package id="NFX" version="3.5.0.5" targetFramework="net40" />
-  <package id="NLog" version="4.4.12" targetFramework="net40" requireReinstallation="true" />
+  <package id="NLog" version="4.4.12" targetFramework="net40" />
   <package id="System.Data.SQLite.Core" version="1.0.112.0" targetFramework="net461" />
 </packages>

--- a/WorkloadToolsTests/WorkloadToolsTests.csproj
+++ b/WorkloadToolsTests/WorkloadToolsTests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WorkloadToolsTests</RootNamespace>
     <AssemblyName>WorkloadToolsTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
@@ -20,6 +20,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/WorkloadToolsTests/app.config
+++ b/WorkloadToolsTests/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.SqlServer.XE.Core" publicKeyToken="89845dcd8080cc91" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-14.100.0.0" newVersion="14.100.0.0" />
+        <assemblyIdentity name="Microsoft.SqlServer.XE.Core" publicKeyToken="89845dcd8080cc91" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-14.100.0.0" newVersion="14.100.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/WorkloadViewer/App.config
+++ b/WorkloadViewer/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/WorkloadViewer/Properties/Resources.Designer.cs
+++ b/WorkloadViewer/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace WorkloadViewer.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {

--- a/WorkloadViewer/Properties/Settings.Designer.cs
+++ b/WorkloadViewer/Properties/Settings.Designer.cs
@@ -8,21 +8,17 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace WorkloadViewer.Properties
-{
-
-
+namespace WorkloadViewer.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.3.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
             }
         }

--- a/WorkloadViewer/WorkloadViewer.csproj
+++ b/WorkloadViewer/WorkloadViewer.csproj
@@ -8,12 +8,13 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>WorkloadViewer</RootNamespace>
     <AssemblyName>WorkloadViewer</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
I'm just updating target framework to .net 4.8, the last long term support release of the .net framework. New systems rarely have 4.6.1 or even 4.7 anymore. The next step would be to convert the projects to the newer SDK style project format which would then facilitate migration to .net core (.net 6 and above). I think that with Microsoft [discontinuing distributed replay in 2022](https://learn.microsoft.com/en-us/sql/tools/distributed-replay/sql-server-distributed-replay?view=sql-server-ver16), your project is very important for the community 😁
