### PR TITLE
Improve performance and fix bugs mostly in ReplayConsumer and FileWorkloadListener

### DIFF
--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.3")]
-[assembly: AssemblyFileVersion("1.6.3")]
+[assembly: AssemblyVersion("1.6.4")]
+[assembly: AssemblyFileVersion("1.6.4")]

--- a/SqlWorkload/NLog.config
+++ b/SqlWorkload/NLog.config
@@ -4,13 +4,13 @@
       xsi:schemaLocation="http://www.nlog-project.org/schemas/NLog.xsd NLog.xsd"
       autoReload="true"
       throwExceptions="false"
-      internalLogLevel="Off" internalLogFile="c:\temp\nlog-internal.log">
-
+      internalLogLevel="Off" 
+      internalLogFile="c:\temp\nlog-internal.log">
 
   <targets>
-    <target name="logfile" xsi:type="File" fileName="SqlWorkload.log" layout="${longdate} - ${level} - ${logger} : ${message}" />
-    <target name="warnfile" xsi:type="File" fileName="Warnings.log" layout="${longdate} - ${message}" />
-    <target name="console" xsi:type="Console" layout="${level} - ${logger} : ${message}"/>
+    <target name="logfile" xsi:type="File" fileName="SqlWorkload.log" layout="${longdate} - ${level} - ${logger}${when:when='${event-properties:item=Worker}'=='':else=(${event-properties:item=Worker})} : ${message:withexception=true}" />
+    <target name="warnfile" xsi:type="File" fileName="Warnings.log" layout="${longdate} - ${logger}${when:when='${event-properties:item=Worker}'=='':else=(${event-properties:item=Worker})} - ${message:withexception=true}" />
+    <target name="console" xsi:type="ColoredConsole" layout="${level} - ${logger}${when:when='${event-properties:item=Worker}'=='':else=(${event-properties:item=Worker})} : ${message:withexception=true}"/>
   </targets>
 
   <rules>

--- a/SqlWorkload/SqlWorkload.csproj
+++ b/SqlWorkload/SqlWorkload.csproj
@@ -61,13 +61,18 @@
       <HintPath>..\packages\DouglasCrockford.JsMin.1.1.3\lib\net40-client\DouglasCrockford.JsMin.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.4.12\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.7.15\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.SQLite, Version=1.0.112.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Data.SQLite.Core.1.0.112.0\lib\net46\System.Data.SQLite.dll</HintPath>
     </Reference>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/SqlWorkload/packages.config
+++ b/SqlWorkload/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="CommandLineParser" version="1.9.71" targetFramework="net451" />
   <package id="DouglasCrockford.JsMin" version="1.1.3" targetFramework="net451" />
-  <package id="NLog" version="4.4.12" targetFramework="net451" />
+  <package id="NLog" version="4.7.15" targetFramework="net48" />
   <package id="System.Data.SQLite.Core" version="1.0.112.0" targetFramework="net461" />
 </packages>

--- a/WorkloadTools/Consumer/BufferedWorkloadConsumer.cs
+++ b/WorkloadTools/Consumer/BufferedWorkloadConsumer.cs
@@ -6,10 +6,14 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using NLog;
+
 namespace WorkloadTools.Consumer
 {
     public abstract class BufferedWorkloadConsumer : WorkloadConsumer
     {
+        private static Logger logger = LogManager.GetCurrentClassLogger();
+
         protected bool stopped = false;
         protected ConcurrentQueue<WorkloadEvent> Buffer { get; set; } = new ConcurrentQueue<WorkloadEvent>();
         protected Task BufferReader { get; set; }
@@ -26,10 +30,12 @@ namespace WorkloadTools.Consumer
             // Ensure that the buffer does not get too big
             while (Buffer.Count >= BufferSize)
             {
+                logger.Trace("Buffer is full so spinning");
                 spin.SpinOnce();
             }
 
             // If the buffer has room, enqueue the event
+            logger.Trace("Adding event {eventType} with start time {startTime:yyyy-MM-ddTHH\\:mm\\:ss.fffffff} to buffer", evt.Type, evt.StartTime);
             Buffer.Enqueue(evt);
 
             if(BufferReader == null)
@@ -64,6 +70,5 @@ namespace WorkloadTools.Consumer
         }
 
         public abstract void ConsumeBuffered(WorkloadEvent evt);
-
     }
 }

--- a/WorkloadTools/Consumer/Replay/ReplayCommand.cs
+++ b/WorkloadTools/Consumer/Replay/ReplayCommand.cs
@@ -10,7 +10,8 @@ namespace WorkloadTools.Consumer.Replay
         public string CommandText { get; set; }
         public string Database { get; set; }
         public string ApplicationName { get; set; }
-        public long ReplayOffset { get; set; } = 0; // milliseconds
+        public double ReplayOffset { get; set; } = 0; // milliseconds
+        public DateTime StartTime { get; set; }
         public long? EventSequence { get; set; }
     }
 }

--- a/WorkloadTools/Consumer/Replay/ReplayConsumer.cs
+++ b/WorkloadTools/Consumer/Replay/ReplayConsumer.cs
@@ -1,12 +1,11 @@
-using NLog;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using WorkloadTools.Consumer.Replay;
+
+using NLog;
 
 namespace WorkloadTools.Consumer.Replay
 {
@@ -19,17 +18,31 @@ namespace WorkloadTools.Consumer.Replay
         public int InactiveWorkerTerminationTimeoutSeconds = 300;
         private Semaphore WorkLimiter;
 
-		public bool DisplayWorkerStats { get; set; } = true;
-		public bool ConsumeResults { get; set; } = true;
-		public int QueryTimeoutSeconds { get; set; } = 30;
-		public int WorkerStatsCommandCount { get; set; } = 1000;
-		public bool MimicApplicationName { get; set; } = false;
+        public bool DisplayWorkerStats { get; set; } = true;
+        public bool ConsumeResults { get; set; } = true;
+        public int QueryTimeoutSeconds { get; set; } = 30;
+        public int WorkerStatsCommandCount { get; set; } = 1000;
+        public bool MimicApplicationName { get; set; } = false;
         public int FailRetryCount { get; set; } = 0;
         public int TimeoutRetryCount { get; set; } = 0;
+        public bool RaiseErrorsToSqlEventTracing { get; private set; } = true;
+
+        private LogLevel _CommandErrorLogLevel = LogLevel.Error;
+        public string CommandErrorLogLevel
+        {
+            get
+            {
+                return _CommandErrorLogLevel.Name;
+            }
+            set
+            {
+                _CommandErrorLogLevel = LogLevel.FromString(value);
+            }
+        }
 
         public Dictionary<string, string> DatabaseMap { get; set; } = new Dictionary<string, string>();
 
-		public SqlConnectionInfo ConnectionInfo { get; set; }
+        public SqlConnectionInfo ConnectionInfo { get; set; }
         public ThreadingModeEnum ThreadingMode { get; set; } = ThreadingModeEnum.WorkerTask;
 
         private ConcurrentDictionary<int, ReplayWorker> ReplayWorkers = new ConcurrentDictionary<int, ReplayWorker>();
@@ -59,21 +72,24 @@ namespace WorkloadTools.Consumer.Replay
 
         public override void ConsumeBuffered(WorkloadEvent evnt)
         {
-            if(evnt is MessageWorkloadEvent)
+            if (evnt is MessageWorkloadEvent messageEvent)
             {
-                MessageWorkloadEvent msgEvent = evnt as MessageWorkloadEvent;
-                if (msgEvent.MsgType == MessageWorkloadEvent.MessageType.TotalEvents)
+                if (messageEvent.MsgType == MessageWorkloadEvent.MessageType.TotalEvents)
                 {
                     try
                     {
-                        totalEventCount = (long)msgEvent.Value;
+                        totalEventCount = (long)messageEvent.Value;
                     }
                     catch (Exception e)
                     {
-                        logger.Error($"Unable to set the total number of events: {e.Message}");
+                        logger.Error(e, $"Unable to set the total number of events");
                     }
                 }
             }
+
+            // totalEventCount is EVERY Event except the initial MessageWorkloadEvent for the TotalEvents,
+            // so always increment the counter.
+            eventCount++;
 
             if (!(evnt is ExecutionWorkloadEvent))
                 return;
@@ -81,16 +97,27 @@ namespace WorkloadTools.Consumer.Replay
             if (evnt.Type != WorkloadEvent.EventType.RPCStarting && evnt.Type != WorkloadEvent.EventType.BatchStarting)
                 return;
 
-            eventCount++;
-            if ((eventCount > 0) && (eventCount % WorkerStatsCommandCount == 0))
+            if (totalEventCount > 0)
             {
-                string percentInfo = (totalEventCount > 0) ? "( " + ((eventCount * 100) / totalEventCount).ToString() + "% )" : "";
-                logger.Info($"{eventCount} events queued for replay {percentInfo}");
+                if (eventCount % (totalEventCount / 1000) == 0)
+                {
+                    var percentInfo = eventCount / totalEventCount;
+                    logger.Info("{eventCount} ({percentInfo:P}) events replayed - {bufferedEventCount} events buffered", eventCount, percentInfo, Buffer.Count);
+                }
+            }
+            else
+            {
+                if (eventCount % WorkerStatsCommandCount == 0)
+                {
+                    logger.Info("{eventCount} events replayed - {bufferedEventCount} events buffered", eventCount, Buffer.Count);
+                }
             }
 
             if (startTime == DateTime.MinValue)
             {
-                startTime = DateTime.Now;
+                // Pad the start time so that the first event isn't behind by the time the worker has started up on a thread.
+                startTime = DateTime.Now.AddTicks(TimeSpan.TicksPerSecond);
+                logger.Info("All future delays will be calculated from this point + 1s, triggered by event {@event}", evnt);
             }
 
             ExecutionWorkloadEvent evt = (ExecutionWorkloadEvent)evnt;
@@ -101,6 +128,7 @@ namespace WorkloadTools.Consumer.Replay
                 Database = evt.DatabaseName,
                 ApplicationName = evt.ApplicationName,
                 ReplayOffset = evt.ReplayOffset,
+                StartTime = evt.StartTime,
                 EventSequence = evt.EventSequence
             };
 
@@ -119,53 +147,37 @@ namespace WorkloadTools.Consumer.Replay
             }
             else
             {
-                rw = new ReplayWorker()
+                logger.Debug("Creating Worker {Worker}", session_id);
+
+                rw = new ReplayWorker(session_id.ToString())
                 {
                     ConnectionInfo = this.ConnectionInfo,
                     ReplayIntervalSeconds = 0,
                     StopOnError = false,
-                    Name = session_id.ToString(),
-					DisplayWorkerStats = this.DisplayWorkerStats,
-					ConsumeResults = this.ConsumeResults,
-					QueryTimeoutSeconds = this.QueryTimeoutSeconds,
-					WorkerStatsCommandCount = this.WorkerStatsCommandCount,
-					MimicApplicationName = this.MimicApplicationName,
+                    DisplayWorkerStats = this.DisplayWorkerStats,
+                    ConsumeResults = this.ConsumeResults,
+                    QueryTimeoutSeconds = this.QueryTimeoutSeconds,
+                    WorkerStatsCommandCount = this.WorkerStatsCommandCount,
+                    MimicApplicationName = this.MimicApplicationName,
                     DatabaseMap = this.DatabaseMap,
                     StartTime = startTime,
                     FailRetryCount = this.FailRetryCount,
-                    TimeoutRetryCount = this.TimeoutRetryCount
+                    TimeoutRetryCount = this.TimeoutRetryCount,
+                    CommandErrorLogLevel = _CommandErrorLogLevel,
+                    RaiseErrorsToSqlEventTracing = this.RaiseErrorsToSqlEventTracing
                 };
+
                 ReplayWorkers.TryAdd(session_id, rw);
                 rw.AppendCommand(command);
-
-                logger.Info($"Worker [{session_id}] - Starting");
             }
 
-            if(runner == null)
-            {
-
-                runner = new Thread(new ThreadStart(
-                                delegate
-                                {
-                                    try
-                                    {
-                                        RunWorkers();
-                                    }
-                                    catch (Exception e)
-                                    {
-                                        try { logger.Error(e, "Unhandled exception in ReplayConsumer.RunWorkers"); }
-                                        catch { Console.WriteLine(e.Message); }
-                                    }
-                                }
-                                ));
-                runner.IsBackground = true;
-                runner.Start();
-            }
-
+            // Ensure the worker is running.
+            // If new it needs starting for the first time.
+            // If existing it may have stopped if the command queue became empty.
+            RunWorker(rw);
 
             if (sweeper == null)
             {
-
                 sweeper = new Thread(new ThreadStart(
                                 delegate
                                 {
@@ -183,21 +195,17 @@ namespace WorkloadTools.Consumer.Replay
                 sweeper.IsBackground = true;
                 sweeper.Start();
             }
-
         }
-
 
         protected override void Dispose(bool disposing)
         {
-            foreach(var r in ReplayWorkers.Values)
+            foreach (var r in ReplayWorkers.Values)
             {
                 r.Dispose();
             }
             WorkLimiter.Dispose();
             stopped = true;
         }
-
-
 
         // Sweeper thread: removes from the workers list all the workers
         // that have not executed a command in the last 5 minutes
@@ -231,16 +239,14 @@ namespace WorkloadTools.Consumer.Replay
 
                 Thread.Sleep(InactiveWorkerTerminationTimeoutSeconds * 1000); // sleep some seconds
             }
-            logger.Trace("Sweeper thread stopped.");
+            logger.Trace("Sweeper thread stopped");
         }
-
-
 
         private void RemoveWorker(string name)
         {
             ReplayWorker outWrk;
-            ReplayWorkers.TryRemove(Int32.Parse(name), out outWrk);
-            logger.Trace($"Worker [{name}] - Disposing");
+            ReplayWorkers.TryRemove(int.Parse(name), out outWrk);
+            logger.Trace("Disposing worker [{Worker}]", name);
             if (outWrk != null)
             {
                 outWrk.Stop();
@@ -249,131 +255,111 @@ namespace WorkloadTools.Consumer.Replay
         }
 
 
-        private void RunWorkers()
+        private void RunWorker(ReplayWorker wrk)
         {
-            while (!stopped)
+            try
             {
-                if (ReplayWorkers.IsEmpty)
-                {
-                    Thread.Sleep(100);
-                    continue;
-                }
+                if (stopped) return;
 
-
-                try
+                if (wrk.HasCommands)
                 {
-                    foreach (ReplayWorker wrk in ReplayWorkers.Values)
+                    if (ThreadingMode == ThreadingModeEnum.ThreadPools)
                     {
-                        if (stopped) return;
-
-                        if (wrk.IsStopped)
+                        try
                         {
-                            RemoveWorker(wrk.Name);
-                        }
+                            // Using a semaphore to avoid overwhelming the threadpool
+                            // Without this precaution, the memory consumption goes to the roof
+                            WorkLimiter.WaitOne();
 
-                        if (wrk.HasCommands)
-                        {
-
-                            if (ThreadingMode == ThreadingModeEnum.ThreadPools)
-                            {
-                                try
+                            // Queue the execution of a statement in the threadpool.
+                            // The statement will get executed in a separate thread eventually.
+                            ThreadPool.QueueUserWorkItem(
+                                delegate
                                 {
-                                    // Using a semaphore to avoid overwhelming the threadpool
-                                    // Without this precaution, the memory consumption goes to the roof
-                                    WorkLimiter.WaitOne();
-
-                                    // Queue the execution of a statement in the threadpool.
-                                    // The statement will get executed in a separate thread eventually.
-                                    ThreadPool.QueueUserWorkItem(delegate { try { wrk.ExecuteNextCommand(); } catch (Exception e) { try { logger.Error(e, "Unhandled exception in ReplayWorker.ExecuteCommand"); } catch { Console.WriteLine(e.Message); } } });
-                                }
-                                finally
-                                {
-                                    // Release the semaphore
-                                    WorkLimiter.Release();
-                                }
-                            }
-                            else if (ThreadingMode == ThreadingModeEnum.Tasks)
-                            {
-                                try
-                                {
-                                    // Using a semaphore to avoid overwhelming the threadpool
-                                    // Without this precaution, the memory consumption goes to the roof
-                                    WorkLimiter.WaitOne();
-
-                                    // Start a new Task to run the statement
-                                    Task t = Task.Factory.StartNew(delegate { try { wrk.ExecuteNextCommand(); } catch (Exception e) { try { logger.Error(e, "Unhandled exception in ReplayWorker.ExecuteCommand"); } catch { Console.WriteLine(e.Message); } } });
-                                }
-                                finally
-                                {
-                                    // Release the semaphore
-                                    WorkLimiter.Release();
-                                }
-                            }
-                            else if (ThreadingMode == ThreadingModeEnum.WorkerTask)
-                            {
-                                try
-                                {
-                                    if (!wrk.IsRunning)
+                                    try
                                     {
-                                        wrk.Start();
+                                        wrk.ExecuteNextCommand();
+                                    }
+                                    catch (Exception e)
+                                    {
+                                        try
+                                        {
+                                            logger.Error(e, "Unhandled exception in ReplayWorker.ExecuteCommand");
+                                        }
+                                        catch
+                                        {
+                                            Console.WriteLine(e.Message);
+                                        }
                                     }
                                 }
-                                catch (Exception e)
-                                {
-                                    logger.Error(e, "Exception in ReplayWorker.RunWorkers - WorkerTask");
-                                }
-                            }
-                            else if (ThreadingMode == ThreadingModeEnum.Serial)
-                            {
-                                try
-                                {
-                                    wrk.ExecuteNextCommand();
-                                }
-                                catch (Exception e)
-                                {
-                                    logger.Error(e, "Exception in ReplayWorker.RunWorkers - WorkerTask");
-                                }
-                            }
+                                );
                         }
-                    };
-
-
-                    if (ThreadingMode == ThreadingModeEnum.WorkerTask)
-                    {
-                        // Sleep 1 second before checking whether more workers
-                        // are available and not started
-                        Thread.Sleep(1000);
+                        finally
+                        {
+                            // Release the semaphore
+                            WorkLimiter.Release();
+                        }
                     }
-                    else
+                    else if (ThreadingMode == ThreadingModeEnum.Tasks)
                     {
-                        // Sleep 1 millisecond after every execution of all the statements
-                        // queued in the ReplayWorkers. 
-                        // This sleep is absolutely necessary to avoid burning CPU when
-                        // all the ReplayWorkers do not contain any statements.
-                        Thread.Sleep(1);
+                        // TODO: Is this not the same as WorkerTask?
+                        // Here the task is created by ReplayConsumer.
+                        // With WorkerTask the task is created by ReplayWorker.Start.
+                        try
+                        {
+                            // Using a semaphore to avoid overwhelming the threadpool
+                            // Without this precaution, the memory consumption goes to the roof
+                            WorkLimiter.WaitOne();
+
+                            // Start a new Task to run the statement
+                            Task t = Task.Factory.StartNew(
+                                delegate
+                                {
+                                    try
+                                    {
+                                        wrk.ExecuteNextCommand();
+                                    }
+                                    catch (Exception e)
+                                    {
+                                        try
+                                        {
+                                            logger.Error(e, "Unhandled exception in ReplayWorker.ExecuteCommand");
+                                        }
+                                        catch
+                                        {
+                                            Console.WriteLine(e.Message);
+                                        }
+                                    }
+                                }
+                                );
+                        }
+                        finally
+                        {
+                            // Release the semaphore
+                            WorkLimiter.Release();
+                        }
+                    }
+                    else if (ThreadingMode == ThreadingModeEnum.WorkerTask)
+                    {
+                        if (!wrk.IsRunning)
+                        {
+                            wrk.Start();
+                        }
+                    }
+                    else if (ThreadingMode == ThreadingModeEnum.Serial)
+                    {
+                        wrk.ExecuteNextCommand();
                     }
                 }
-                catch (InvalidOperationException)
-                {
-                    //ignore ...
-                }
-                catch (Exception ex)
-                {
-                    logger.Error(ex, "Exception in ReplayWorker.RunWorkers");
-                }
-
             }
-
-
-            if (ThreadingMode == ThreadingModeEnum.WorkerTask)
+            catch (InvalidOperationException)
             {
-                foreach (ReplayWorker wrk in ReplayWorkers.Values)
-                {
-                    wrk.Stop();
-                    wrk.Dispose();
-                }
+                //ignore ...
             }
-            logger.Trace("Worker thread stopped.");
+            catch (Exception ex)
+            {
+                logger.Error(ex, "Error starting worker");
+            }
         }
 
         public override bool HasMoreEvents()

--- a/WorkloadTools/Consumer/WorkloadFile/WorkloadFileWriterConsumer.cs
+++ b/WorkloadTools/Consumer/WorkloadFile/WorkloadFileWriterConsumer.cs
@@ -415,6 +415,11 @@ namespace WorkloadTools.Consumer.WorkloadFile
 	                event_sequence DESC
                 );
 
+                CREATE INDEX IF NOT EXISTS Index_Start_Time_Row_ID ON Events(
+	                Start_Time ASC,
+	                Row_ID ASC
+                );
+
                 CREATE TABLE IF NOT EXISTS Counters (
                     row_id INTEGER,
                     name TEXT NULL,

--- a/WorkloadTools/ExecutionWorkloadEvent.cs
+++ b/WorkloadTools/ExecutionWorkloadEvent.cs
@@ -21,6 +21,6 @@ namespace WorkloadTools
         public long? EventSequence { get; set; }
         // This is the requested offset in milliseconds
         // from the the beginning of the workload
-        public long ReplayOffset { get; set; } = 0; // MILLISECONDS 
+        public double ReplayOffset { get; set; } = 0; // MILLISECONDS 
     }
 }

--- a/WorkloadTools/WorkloadController.cs
+++ b/WorkloadTools/WorkloadController.cs
@@ -24,14 +24,12 @@ namespace WorkloadTools
         private bool disposed = false;
         private const int MAX_DISPOSE_TIMEOUT_SECONDS = 5;
 
-
         public WorkloadController()
         {
         }
 
         public void Run()
         {
-
             try
             {
 				var startTime = Listener.StartAt;
@@ -39,15 +37,15 @@ namespace WorkloadTools
 
                 Listener.Initialize();
 
-                logger.Info($"Listener of type {Listener.GetType().Name} initialized correctly.");
-                logger.Info($"Event collection starts at {startTime.ToString("yyyy-MM-dd HH:mm:ss")}.");
+                logger.Info("Listener of type {ListenerTypeName} initialized correctly", Listener.GetType().Name);
+                logger.Info("Event collection starts at {startTime}", startTime);
                 // wait until Listener.StartAt has been reached
                 while (DateTime.Now.CompareTo(startTime) < 0)
                 {
                     Thread.Sleep(100);
                 }
 
-                logger.Info("Waiting for events.");
+                logger.Info("Waiting for events");
 
                 do
                 {
@@ -98,8 +96,6 @@ namespace WorkloadTools
                 }
             }
         }
-
-
 
         public void Stop()
         {

--- a/WorkloadTools/WorkloadTools.csproj
+++ b/WorkloadTools/WorkloadTools.csproj
@@ -197,13 +197,18 @@
       <HintPath>..\packages\NFX.3.5.0.5\lib\NFX.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.4.12\lib\net40\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.7.15\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.SQLite, Version=1.0.112.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Data.SQLite.Core.1.0.112.0\lib\net46\System.Data.SQLite.dll</HintPath>
     </Reference>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/WorkloadTools/packages.config
+++ b/WorkloadTools/packages.config
@@ -4,6 +4,6 @@
   <package id="FastMember" version="1.5.0" targetFramework="net461" />
   <package id="Microsoft.SqlServer.SqlManagementObjects" version="140.17279.0" targetFramework="net40" />
   <package id="NFX" version="3.5.0.5" targetFramework="net40" />
-  <package id="NLog" version="4.4.12" targetFramework="net40" />
+  <package id="NLog" version="4.7.15" targetFramework="net48" />
   <package id="System.Data.SQLite.Core" version="1.0.112.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
- Upgrade NLog to 4.7.15 to support structured logging and start deployment of structured logging in Replay consumer.
- Add warning if the delay is skipped because processing is behind.
- Fix FileWorkloadListener count being wrong when applying filters.
- Fix FileWorkloadListener returning events with no event sequence first, which causes synchronized mode to not work because the start time could be any time within the replay.
- Fix FileWorkloadListener causing the Sqlite result set to slowly copy to a temp file due to no index in the Events table (index added in WorkloadFileWriterConsumer).
- Fix ReplayWorker threads may sleep for too long due to hardware thread-exhaustion on busy workloads. By creating the tasks as LongRunning thread over-subscription is allowed which works well when there are lots of threads that may be sleeping.
- Fix ReplayWorker wasting threads by ending the Task when the command queue is empty. ReplayConsumer will restart it when the next command is dequeued or it will be disposed when InactiveWorkerTerminationTimeoutSeconds is reached.
- Fix ReplayOffset is inconsistently a long or double.
- Enhance ReplayWorker to make publishing errors to sp_trace_generateevent optional to improve performance when it isn't required (RaiseErrorsToSqlEventTracing parameter).
- Enhance ReplayWorker to allow errors to output to NLog at a customisable level (CommandErrorLogLevel parameter).
- Enhance ReplayWorker to include the name of the session in every log message.