### PR TITLE
Fix #139 - Incorrect application name in replays

### DIFF
--- a/WorkloadTools/Consumer/Analysis/WorkloadAnalyzer.cs
+++ b/WorkloadTools/Consumer/Analysis/WorkloadAnalyzer.cs
@@ -398,7 +398,7 @@ namespace WorkloadTools.Consumer.Analysis
 
             using (var conn = new SqlConnection())
             {
-                conn.ConnectionString = ConnectionInfo.ConnectionString;
+                conn.ConnectionString = ConnectionInfo.ConnectionString();
                 conn.Open();
 
                 if (!TargetTableCreated)
@@ -1012,7 +1012,7 @@ namespace WorkloadTools.Consumer.Analysis
 
 			using (var conn = new SqlConnection())
             {
-                conn.ConnectionString = ConnectionInfo.ConnectionString;
+                conn.ConnectionString = ConnectionInfo.ConnectionString();
                 conn.Open();
 
                 var sql = string.Format(@"SELECT * FROM [{0}].[Applications]",ConnectionInfo.SchemaName);
@@ -1069,7 +1069,7 @@ namespace WorkloadTools.Consumer.Analysis
 
             using (var conn = new SqlConnection())
             {
-                conn.ConnectionString = ConnectionInfo.ConnectionString;
+                conn.ConnectionString = ConnectionInfo.ConnectionString();
                 conn.Open();
                 conn.ChangeDatabase(ConnectionInfo.DatabaseName);
 
@@ -1130,7 +1130,7 @@ namespace WorkloadTools.Consumer.Analysis
 			{
 				using (var conn = new SqlConnection())
 				{
-					conn.ConnectionString = ConnectionInfo.ConnectionString;
+					conn.ConnectionString = ConnectionInfo.ConnectionString();
 					conn.Open();
 					conn.ChangeDatabase(ConnectionInfo.DatabaseName);
 					using (var cmd = conn.CreateCommand())

--- a/WorkloadTools/Listener/ExtendedEvents/ExtendedEventsWorkloadListener.cs
+++ b/WorkloadTools/Listener/ExtendedEvents/ExtendedEventsWorkloadListener.cs
@@ -54,7 +54,7 @@ namespace WorkloadTools.Listener.ExtendedEvents
                 {
                     throw new ArgumentNullException("You need to provide ConnectionInfo to inizialize an ExtendedEventsWorkloadListener");
                 }
-                conn.ConnectionString = ConnectionInfo.ConnectionString;
+                conn.ConnectionString = ConnectionInfo.ConnectionString();
                 conn.Open();
 
                 LoadServerType(conn);
@@ -207,7 +207,7 @@ namespace WorkloadTools.Listener.ExtendedEvents
                 {
                     using (var conn = new SqlConnection())
                     {
-                        conn.ConnectionString = ConnectionInfo.ConnectionString;
+                        conn.ConnectionString = ConnectionInfo.ConnectionString();
                         conn.Open();
                         StopSession(conn);
                     }
@@ -279,11 +279,11 @@ namespace WorkloadTools.Listener.ExtendedEvents
 
                 if (serverType != ServerType.AzureSqlDatabase && FileTargetPath == null)
                 {
-                    reader = new StreamXEventDataReader(ConnectionInfo.ConnectionString, SessionName, Events);
+                    reader = new StreamXEventDataReader(ConnectionInfo.ConnectionString(), SessionName, Events);
                 }
                 else
                 {
-                    reader = new FileTargetXEventDataReader(ConnectionInfo.ConnectionString, SessionName, Events, serverType);
+                    reader = new FileTargetXEventDataReader(ConnectionInfo.ConnectionString(), SessionName, Events, serverType);
                 }
 
                 reader.ReadEvents();

--- a/WorkloadTools/Listener/Trace/SqlTraceWorkloadListener.cs
+++ b/WorkloadTools/Listener/Trace/SqlTraceWorkloadListener.cs
@@ -50,7 +50,7 @@ namespace WorkloadTools.Listener.Trace
         {
             using (var conn = new SqlConnection())
             {
-                conn.ConnectionString = ConnectionInfo.ConnectionString;
+                conn.ConnectionString = ConnectionInfo.ConnectionString();
                 conn.Open();
 
                 string traceSql = null;
@@ -135,7 +135,7 @@ namespace WorkloadTools.Listener.Trace
 
         private void ReadEventsFromTDS()
         {
-            using (var reader = new FileTraceEventDataReader(ConnectionInfo.ConnectionString, Filter, Events))
+            using (var reader = new FileTraceEventDataReader(ConnectionInfo.ConnectionString(), Filter, Events))
             {
                 reader.ReadEvents();
             }
@@ -247,7 +247,7 @@ namespace WorkloadTools.Listener.Trace
             stopped = true;
             using (var conn = new SqlConnection())
             {
-                conn.ConnectionString = ConnectionInfo.ConnectionString;
+                conn.ConnectionString = ConnectionInfo.ConnectionString();
                 conn.Open();
                 StopTrace(conn, traceId);
             }

--- a/WorkloadTools/SqlConnectionInfo.cs
+++ b/WorkloadTools/SqlConnectionInfo.cs
@@ -17,52 +17,54 @@ namespace WorkloadTools
         public bool TrustServerCertificate { get; set; } = false;
         public string ApplicationName { get; set; } = "WorkloadTools";
         public int MaxPoolSize { get; set; } = 500;
-        public Dictionary<string, string> DatabaseMap { get; set;} = new Dictionary<string, string>();
-            
-        public string ConnectionString
+        public Dictionary<string, string> DatabaseMap { get; set; } = new Dictionary<string, string>();
+
+        public string ConnectionString()
         {
-            get
+            return ConnectionString(ApplicationName);
+        }
+
+        public string ConnectionString(string applicationName)
+        {
+            var connectionString = "Data Source=" + ServerName + "; ";
+            connectionString += "Max Pool Size = " + MaxPoolSize + "; ";
+            if (string.IsNullOrEmpty(DatabaseName))
             {
-                var connectionString = "Data Source=" + ServerName + "; ";
-                connectionString += "Max Pool Size = " + MaxPoolSize + "; ";
-                if (string.IsNullOrEmpty(DatabaseName))
-                {
-                    connectionString += "Initial Catalog = master; ";
-                }
-                else
-                {
-                    // try to replace database name with the name
-                    // in the database map, if any
-                    var effectiveDatabaseName = DatabaseName;
-                    if (DatabaseMap.ContainsKey(DatabaseName))
-                    {
-                        effectiveDatabaseName = DatabaseMap[DatabaseName];
-                    }
-                    connectionString += "Initial Catalog = " + effectiveDatabaseName + "; ";
-                }
-                if (string.IsNullOrEmpty(UserName))
-                {
-                    connectionString += "Integrated Security = SSPI; ";
-                }
-                else
-                {
-                    connectionString += "User Id = " + UserName + "; ";
-                    connectionString += "Password = " + Password + "; ";
-                }
-                if (!string.IsNullOrEmpty(ApplicationName))
-                {
-                    connectionString += "Application Name = "+ ApplicationName +"; ";
-                }
-                if (Encrypt)
-                {
-                    connectionString += "Encrypt = true; ";
-                }
-                if (TrustServerCertificate)
-                {
-                    connectionString += "TrustServerCertificate = true; ";
-                }
-                return connectionString;
+                connectionString += "Initial Catalog = master; ";
             }
+            else
+            {
+                // try to replace database name with the name
+                // in the database map, if any
+                var effectiveDatabaseName = DatabaseName;
+                if (DatabaseMap.ContainsKey(DatabaseName))
+                {
+                    effectiveDatabaseName = DatabaseMap[DatabaseName];
+                }
+                connectionString += "Initial Catalog = " + effectiveDatabaseName + "; ";
+            }
+            if (string.IsNullOrEmpty(UserName))
+            {
+                connectionString += "Integrated Security = SSPI; ";
+            }
+            else
+            {
+                connectionString += "User Id = " + UserName + "; ";
+                connectionString += "Password = " + Password + "; ";
+            }
+            if (!string.IsNullOrEmpty(applicationName))
+            {
+                connectionString += "Application Name = " + applicationName + "; ";
+            }
+            if (Encrypt)
+            {
+                connectionString += "Encrypt = true; ";
+            }
+            if (TrustServerCertificate)
+            {
+                connectionString += "TrustServerCertificate = true; ";
+            }
+            return connectionString;
         }
     }
 }

--- a/WorkloadTools/WorkloadListener.cs
+++ b/WorkloadTools/WorkloadListener.cs
@@ -172,7 +172,7 @@ namespace WorkloadTools
 
             using (var conn = new SqlConnection())
             {
-                conn.ConnectionString = ConnectionInfo.ConnectionString;
+                conn.ConnectionString = ConnectionInfo.ConnectionString();
                 conn.Open();
                 // Calculate CPU usage during the last minute interval
                 var sql = @"
@@ -369,7 +369,7 @@ namespace WorkloadTools
 
             using (var conn = new SqlConnection())
             {
-                conn.ConnectionString = ConnectionInfo.ConnectionString;
+                conn.ConnectionString = ConnectionInfo.ConnectionString();
                 conn.Open();
                 // Calculate waits since instance restart
                 var sql = @"
@@ -460,7 +460,7 @@ namespace WorkloadTools
 
             using (var conn = new SqlConnection())
             {
-                conn.ConnectionString = ConnectionInfo.ConnectionString;
+                conn.ConnectionString = ConnectionInfo.ConnectionString();
                 conn.Open();
                 // Create Marked Transaction
                 var sql = @"


### PR DESCRIPTION
Fix #139 by passing Application Name when asking for a connection string instead of updating a shared object