### PR TITLE
Fix #115 WorkloadViewer shows queries twice

### DIFF
--- a/WorkloadViewer/Comparer/QueryResultEqualityComparer.cs
+++ b/WorkloadViewer/Comparer/QueryResultEqualityComparer.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+using WorkloadViewer.ViewModel;
+
+public class QueryResultEqualityComparer : IEqualityComparer<QueryResult>
+{
+    public bool Equals(QueryResult x, QueryResult y)
+    {
+        return x?.query_hash == y?.query_hash;
+    }
+
+    public int GetHashCode(QueryResult obj)
+    {
+        return obj?.query_hash.GetHashCode() ?? 0;
+    }
+}

--- a/WorkloadViewer/ViewModel/MainViewModel.cs
+++ b/WorkloadViewer/ViewModel/MainViewModel.cs
@@ -322,18 +322,18 @@ namespace WorkloadViewer.ViewModel
                     on b.query.Hash equals k.query.Hash
                     into joinedData
                 from j in joinedData.DefaultIfEmpty()
-                select new
+                select new QueryResult
                 {
                     query_hash = b.query.Hash,
                     query_text = b.query.ExampleText,
                     query_normalized = b.query.NormalizedText,
-                    b.sum_duration_us,
-                    b.avg_duration_us,
-                    b.sum_cpu_us,
-                    b.avg_cpu_us,
-                    b.sum_reads,
-                    b.avg_reads,
-                    b.execution_count,
+                    sum_duration_us = b.sum_duration_us,
+                    avg_duration_us = b.avg_duration_us,
+                    sum_cpu_us = b.sum_cpu_us,
+                    avg_cpu_us = b.avg_cpu_us,
+                    sum_reads = b.sum_reads,
+                    avg_reads = b.avg_reads,
+                    execution_count = b.execution_count,
                     sum_duration_us2 = j == null ? 0 : j.sum_duration_us,
                     diff_sum_duration_us = j == null ? 0 : j.sum_duration_us - b.sum_duration_us,
                     avg_duration_us2 = j == null ? 0 : j.avg_duration_us,
@@ -358,19 +358,19 @@ namespace WorkloadViewer.ViewModel
                     on b.query.Hash equals k.query.Hash
                     into joinedData
                 from j in joinedData.DefaultIfEmpty()
-                select new
+                select new QueryResult
                 {
                     query_hash = b.query.Hash,
                     query_text = b.query.ExampleText,
                     query_normalized = b.query.NormalizedText,
-                    b.sum_duration_us,
-                    b.avg_duration_us,
-                    b.sum_cpu_us,
-                    b.avg_cpu_us,
-                    b.sum_reads,
-                    b.avg_reads,
-                    b.execution_count,
-                    sum_duration_us2     = j == null ? 0 : j.sum_duration_us,
+                    sum_duration_us = b.sum_duration_us,
+                    avg_duration_us = b.avg_duration_us,
+                    sum_cpu_us = b.sum_cpu_us,
+                    avg_cpu_us = b.avg_cpu_us,
+                    sum_reads = b.sum_reads,
+                    avg_reads = b.avg_reads,
+                    execution_count = b.execution_count,
+                    sum_duration_us2 = j == null ? 0 : j.sum_duration_us,
                     diff_sum_duration_us = j == null ? 0 : j.sum_duration_us - b.sum_duration_us,
                     avg_duration_us2 = j == null ? 0 : j.avg_duration_us,
                     diff_avg_duration_us = j == null ? 0 : j.avg_duration_us - b.avg_duration_us,
@@ -388,7 +388,9 @@ namespace WorkloadViewer.ViewModel
                     document = new ICSharpCode.AvalonEdit.Document.TextDocument() { Text = b.query.ExampleText }
                 };
 
-            var merged = leftOuterJoin.Union(rightOuterJoin);
+            var merged = leftOuterJoin
+                .Union(rightOuterJoin, new QueryResultEqualityComparer())
+                .ToList();
 
             Queries = merged;
 

--- a/WorkloadViewer/ViewModel/QueryResult.cs
+++ b/WorkloadViewer/ViewModel/QueryResult.cs
@@ -1,0 +1,59 @@
+﻿using WorkloadViewer.Model;
+
+namespace WorkloadViewer.ViewModel
+{
+    public class QueryResult
+    {
+        public long query_hash { get; set; }
+        
+        public string query_text { get; set; }
+        
+        public string query_normalized { get; set; }
+        
+        public long sum_duration_us { get; set; }
+        
+        public double avg_duration_us { get; set; }
+        
+        public long sum_cpu_us { get; set; }
+        
+        public double avg_cpu_us { get; set; }
+        
+        public long sum_reads { get; set; }
+        
+        public double avg_reads { get; set; }
+        
+        public long execution_count { get; set; }
+        
+        public long sum_duration_us2 { get; set; }
+        
+        public long diff_sum_duration_us { get; set; }
+        
+        public double avg_duration_us2 { get; set; }
+        
+        public double diff_avg_duration_us { get; set; }
+        
+        public long sum_cpu_us2 { get; set; }
+        
+        public long diff_sum_cpu_us { get; set; }
+        
+        public double avg_cpu_us2 { get; set; }
+        
+        public double diff_avg_cpu_us { get; set; }
+        
+        public long sum_reads2 { get; set; }
+        
+        public long diff_sum_reads { get; set; }
+        
+        public double avg_reads2 { get; set; }
+        
+        public double diff_avg_reads { get; set; }
+        
+        public long execution_count2 { get; set; }
+        
+        public long diff_execution_count { get; set; }
+        
+        public QueryDetails querydetails { get; set; }
+        
+        public ICSharpCode.AvalonEdit.Document.TextDocument document { get; set; }
+    }
+}

--- a/WorkloadViewer/WorkloadViewer.csproj
+++ b/WorkloadViewer/WorkloadViewer.csproj
@@ -131,6 +131,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Comparer\QueryResultEqualityComparer.cs" />
     <Compile Include="Model\NormalizedQuery.cs" />
     <Compile Include="Model\SqlConnectionInfo.cs" />
     <Compile Include="Model\WorkloadAnalysis.cs" />
@@ -142,6 +143,7 @@
     <Compile Include="ViewModel\MainViewModel.cs" />
     <Compile Include="Model\QueryDetails.cs" />
     <Compile Include="ViewModel\Message.cs" />
+    <Compile Include="ViewModel\QueryResult.cs" />
     <Compile Include="ViewModel\SortColMessage.cs" />
     <Compile Include="ViewModel\ViewModelLocator.cs" />
     <Page Include="View\ConnectionInfoDialog.xaml">


### PR DESCRIPTION
Hi,

i am not sure why you perform the rightouter join there and merge it with the leftouterjoin because that causes the dublicates. Is it because you can have queries in the benchmark which are not in the baseline?